### PR TITLE
Some memory leakes fixed while using raw tcp sockets 

### DIFF
--- a/src/jcon/json_rpc_endpoint.cpp
+++ b/src/jcon/json_rpc_endpoint.cpp
@@ -101,8 +101,10 @@ void JsonRpcEndpoint::dataReady(const QByteArray& bytes, QObject* socket)
     JCON_ASSERT(bytes.length() > 0);
 	// Copying data to new buffer because endpoint buffer may be invalidated at any time by closing socket from outside 
 	// and we will get here an exception
-    m_recv_buffer += QByteArray::fromRawData(bytes.data(), bytes.size());
-    processBuffer(m_recv_buffer.trimmed(), socket);
+    //m_recv_buffer += QByteArray::fromRawData(bytes.data(), bytes.size());
+    // processBuffer(m_recv_buffer.trimmed(), socket);
+	m_recv_buffer += bytes;
+	m_recv_buffer = processBuffer(m_recv_buffer.trimmed(), socket);
 }
 
 QByteArray JsonRpcEndpoint::processBuffer(const QByteArray& buffer,

--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -4,110 +4,110 @@
 
 namespace jcon {
 
-JsonRpcTcpServer::JsonRpcTcpServer(QObject* parent,
-                                   std::shared_ptr<JsonRpcLogger> logger)
-    : JsonRpcServer(parent, logger)
-    , m_server(this)
-{
-    m_server.connect(&m_server, &QTcpServer::newConnection,
-                     this, &JsonRpcTcpServer::newConnection);
-}
+	JsonRpcTcpServer::JsonRpcTcpServer(QObject* parent,
+		std::shared_ptr<JsonRpcLogger> logger)
+		: JsonRpcServer(parent, logger)
+		, m_server(this)
+	{
+		m_server.connect(&m_server, &QTcpServer::newConnection,
+			this, &JsonRpcTcpServer::newConnection);
+	}
 
-JsonRpcTcpServer::~JsonRpcTcpServer()
-{
-    m_server.disconnect(this);
-    close();
-}
+	JsonRpcTcpServer::~JsonRpcTcpServer()
+	{
+		m_server.disconnect(this);
+		close();
+	}
 
-void JsonRpcTcpServer::listen(int port)
-{
-    logInfo(QString("listening on port %1").arg(port));
-    if (!m_server.listen(QHostAddress::AnyIPv4, port)) {
-        auto msg = QString("Error listening on port %1").arg(port);
-        logError(qPrintable(msg));
-        return;
-    }
-}
+	void JsonRpcTcpServer::listen(int port)
+	{
+		logInfo(QString("listening on port %1").arg(port));
+		if (!m_server.listen(QHostAddress::AnyIPv4, port)) {
+			auto msg = QString("Error listening on port %1").arg(port);
+			logError(qPrintable(msg));
+			return;
+		}
+	}
 
-void JsonRpcTcpServer::listen(const QHostAddress& addr, int port)
-{
-    logInfo(QString("listening on port %1").arg(port));
-    if (!m_server.listen(addr, port)) {
-        auto msg = QString("Error listening on %1:%2")
-            .arg(addr.toString()).arg(port);
-        logError(qPrintable(msg));
-        return;
-    }
-}
+	void JsonRpcTcpServer::listen(const QHostAddress& addr, int port)
+	{
+		logInfo(QString("listening on port %1").arg(port));
+		if (!m_server.listen(addr, port)) {
+			auto msg = QString("Error listening on %1:%2")
+				.arg(addr.toString()).arg(port);
+			logError(qPrintable(msg));
+			return;
+		}
+	}
 
-void JsonRpcTcpServer::close()
-{
-    m_server.close();
-}
+	void JsonRpcTcpServer::close()
+	{
+		m_server.close();
+	}
 
-JsonRpcEndpoint* JsonRpcTcpServer::findClient(QObject* socket)
-{
-    QTcpSocket* tcp_socket = qobject_cast<QTcpSocket*>(socket);
-    auto it = m_client_endpoints.find(tcp_socket);
-    return (it != m_client_endpoints.end()) ? it->second.get() : nullptr;
-}
+	JsonRpcEndpoint* JsonRpcTcpServer::findClient(QObject* socket)
+	{
+		QTcpSocket* tcp_socket = qobject_cast<QTcpSocket*>(socket);
+		auto it = m_client_endpoints.find(tcp_socket);
+		return (it != m_client_endpoints.end()) ? it->second.get() : nullptr;
+	}
 
-void JsonRpcTcpServer::newConnection()
-{
-    JCON_ASSERT(m_server.hasPendingConnections());
-    if (m_server.hasPendingConnections()) {
-        QTcpSocket* tcp_socket = m_server.nextPendingConnection();
-        JCON_ASSERT(m_server.nextPendingConnection() == nullptr);
+	void JsonRpcTcpServer::newConnection()
+	{
+		JCON_ASSERT(m_server.hasPendingConnections());
+		if (m_server.hasPendingConnections()) {
+			QTcpSocket* tcp_socket = m_server.nextPendingConnection();
+			JCON_ASSERT(m_server.nextPendingConnection() == nullptr);
 
-        JCON_ASSERT(tcp_socket);
-        if (!tcp_socket) {
-            logError("pending socket was null");
-            return;
-        }
+			JCON_ASSERT(tcp_socket);
+			if (!tcp_socket) {
+				logError("pending socket was null");
+				return;
+			}
 
-        logInfo("client connected: " + tcp_socket->peerAddress().toString());
+			logInfo("client connected: " + tcp_socket->peerAddress().toString());
 
-        // TODO: maybe move this to base class?
-        // {
-        auto rpc_socket = std::make_shared<JsonRpcTcpSocket>(tcp_socket);
+			// TODO: maybe move this to base class?
+			// {
+			auto rpc_socket = std::make_shared<JsonRpcTcpSocket>(tcp_socket);
 
-        auto endpoint =
-            std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
+			auto endpoint =
+				std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
 
-        connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
-                this, &JsonRpcTcpServer::disconnectClient);
+			connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
+				this, &JsonRpcTcpServer::disconnectClient);
 
-        connect(endpoint.get(), &JsonRpcEndpoint::socketError,
-                this, &JsonRpcServer::socketError);
+			connect(endpoint.get(), &JsonRpcEndpoint::socketError,
+				this, &JsonRpcServer::socketError);
 
-        connect(endpoint.get(), &JsonRpcEndpoint::jsonObjectReceived,
-                this, &JsonRpcServer::jsonRequestReceived);
+			connect(endpoint.get(), &JsonRpcEndpoint::jsonObjectReceived,
+				this, &JsonRpcServer::jsonRequestReceived);
 
-        m_client_endpoints[tcp_socket] = endpoint;
+			m_client_endpoints[tcp_socket] = endpoint;
 
-        emit(clientConnected(tcp_socket));
-        // }
-    }
-}
+			emit(clientConnected(tcp_socket));
+			// }
+		}
+	}
 
-void JsonRpcTcpServer::disconnectClient(QObject* client_socket)
-{
-    QTcpSocket* tcp_socket = qobject_cast<QTcpSocket*>(client_socket);
-    JCON_ASSERT(tcp_socket);
-    if (!tcp_socket) { 
-        logError("client disconnected, but socket is null");
-        return;
-    }
+	void JsonRpcTcpServer::disconnectClient(QObject* client_socket)
+	{
+		QTcpSocket* tcp_socket = qobject_cast<QTcpSocket*>(client_socket);
+		JCON_ASSERT(tcp_socket);
+		if (!tcp_socket) {
+			logError("client disconnected, but socket is null");
+			return;
+		}
 
-    logInfo("client disconnected: " + tcp_socket->peerAddress().toString());
-    auto it = m_client_endpoints.find(tcp_socket);
-    JCON_ASSERT(it != m_client_endpoints.end());
-    if (it == m_client_endpoints.end()) {
-        logError("unknown client disconnected");
-        return;
-    }
-    m_client_endpoints.erase(it);
-    emit(clientDisconnected(client_socket));
-}
+		logInfo("client disconnected: " + tcp_socket->peerAddress().toString());
+		auto it = m_client_endpoints.find(tcp_socket);
+		JCON_ASSERT(it != m_client_endpoints.end());
+		if (it == m_client_endpoints.end()) {
+			logError("unknown client disconnected");
+			return;
+		}
+		m_client_endpoints.erase(it);
+		emit(clientDisconnected(client_socket));
+	}
 
 }

--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -94,7 +94,7 @@ void JsonRpcTcpServer::disconnectClient(QObject* client_socket)
 {
     QTcpSocket* tcp_socket = qobject_cast<QTcpSocket*>(client_socket);
     JCON_ASSERT(tcp_socket);
-    if (!tcp_socket) {
+    if (!tcp_socket) { 
         logError("client disconnected, but socket is null");
         return;
     }

--- a/src/jcon/json_rpc_tcp_socket.cpp
+++ b/src/jcon/json_rpc_tcp_socket.cpp
@@ -18,6 +18,7 @@ JsonRpcTcpSocket::JsonRpcTcpSocket(QTcpSocket* socket)
 JsonRpcTcpSocket::~JsonRpcTcpSocket()
 {
     m_socket->disconnect(this);
+	this->disconnect(m_socket);
 }
 
 void JsonRpcTcpSocket::setupSocket()

--- a/src/jcon/json_rpc_tcp_socket.cpp
+++ b/src/jcon/json_rpc_tcp_socket.cpp
@@ -30,7 +30,8 @@ void JsonRpcTcpSocket::setupSocket()
     });
 
     connect(m_socket, &QTcpSocket::disconnected, this, [this]() {
-        emit socketDisconnected(m_socket);
+		QTcpSocket* this_socket = m_socket;
+        emit socketDisconnected(this_socket);
     });
 
     connect(m_socket, &QTcpSocket::readyRead,
@@ -40,7 +41,9 @@ void JsonRpcTcpSocket::setupSocket()
         &QAbstractSocket::error;
     connect(m_socket, errorFun, this,
             [this](QAbstractSocket::SocketError error) {
-                emit socketError(m_socket, error);
+				QTcpSocket* this_socket = m_socket;
+                emit socketError(this_socket, error);
+				this_socket->close();
             });
 }
 


### PR DESCRIPTION
Fixed memory leak of QSocket objects in json_rpc_tcp_socket.cpp because Qt pools incoming connection on the same QTcpSocket objects