### PR TITLE
Bool listen

### DIFF
--- a/src/jcon/json_rpc_server.h
+++ b/src/jcon/json_rpc_server.h
@@ -23,8 +23,8 @@ public:
 
     void registerServices(const QObjectList& services);
 
-    virtual void listen(int port) = 0;
-    virtual void listen(const QHostAddress& addr, int port) = 0;
+    virtual bool listen(int port) = 0;
+    virtual bool listen(const QHostAddress& addr, int port) = 0;
 
     virtual void close() = 0;
 

--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -19,25 +19,27 @@ JsonRpcTcpServer::~JsonRpcTcpServer()
     close();
 }
 
-void JsonRpcTcpServer::listen(int port)
+bool JsonRpcTcpServer::listen(int port)
 {
     logInfo(QString("listening on port %1").arg(port));
     if (!m_server.listen(QHostAddress::AnyIPv4, port)) {
         auto msg = QString("Error listening on port %1").arg(port);
         logError(qPrintable(msg));
-        return;
+        return false;
     }
+    return true;
 }
 
-void JsonRpcTcpServer::listen(const QHostAddress& addr, int port)
+bool JsonRpcTcpServer::listen(const QHostAddress& addr, int port)
 {
     logInfo(QString("listening on port %1").arg(port));
     if (!m_server.listen(addr, port)) {
         auto msg = QString("Error listening on %1:%2")
             .arg(addr.toString()).arg(port);
         logError(qPrintable(msg));
-        return;
-    }
+        return false;
+    } 
+    return true;
 }
 
 void JsonRpcTcpServer::close()

--- a/src/jcon/json_rpc_tcp_server.h
+++ b/src/jcon/json_rpc_tcp_server.h
@@ -20,8 +20,8 @@ public:
                      std::shared_ptr<JsonRpcLogger> logger = nullptr);
     virtual ~JsonRpcTcpServer();
 
-    void listen(int port) override;
-    void listen(const QHostAddress& addr, int port) override;
+    bool listen(int port) override;
+    bool listen(const QHostAddress& addr, int port) override;
     void close() override;
 
 protected:

--- a/src/jcon/json_rpc_websocket_server.cpp
+++ b/src/jcon/json_rpc_websocket_server.cpp
@@ -27,17 +27,17 @@ JsonRpcWebSocketServer::~JsonRpcWebSocketServer()
     m_server = nullptr;
 }
 
-void JsonRpcWebSocketServer::listen(int port)
+bool JsonRpcWebSocketServer::listen(int port)
 {
     logInfo(QString("listening on port %2").arg(port));
-    m_server->listen(QHostAddress::AnyIPv4, port);
+    return m_server->listen(QHostAddress::AnyIPv4, port);
 }
 
 
-void JsonRpcWebSocketServer::listen(const QHostAddress& addr, int port)
+bool JsonRpcWebSocketServer::listen(const QHostAddress& addr, int port)
 {
     logInfo(QString("listening on port %2").arg(port));
-    m_server->listen(addr, port);
+    return m_server->listen(addr, port);
 }
 
 void JsonRpcWebSocketServer::close()

--- a/src/jcon/json_rpc_websocket_server.h
+++ b/src/jcon/json_rpc_websocket_server.h
@@ -21,8 +21,8 @@ public:
                            std::shared_ptr<JsonRpcLogger> logger = nullptr);
     virtual ~JsonRpcWebSocketServer();
 
-    void listen(int port) override;
-    void listen(const QHostAddress& addr, int port) override;
+    bool listen(int port) override;
+    bool listen(const QHostAddress& addr, int port) override;
     void close() override;
 
 protected:


### PR DESCRIPTION
You should always return the listen result so the app knows if it needs to bail because something is on the same socket (another instance running?)