### PR TITLE
endpoint: Return early on bad request

### DIFF
--- a/src/jcon/json_rpc_endpoint.cpp
+++ b/src/jcon/json_rpc_endpoint.cpp
@@ -138,7 +138,7 @@ QByteArray JsonRpcEndpoint::processBuffer(const QByteArray& buffer,
 
     JCON_ASSERT(buf[0] == '{');
     if (buf[0] != '{') {
-        m_logger->logError("malformed request");
+        m_logger->logError("Malformed request");
         return nullptr;
     }
 

--- a/src/jcon/json_rpc_endpoint.cpp
+++ b/src/jcon/json_rpc_endpoint.cpp
@@ -137,6 +137,10 @@ QByteArray JsonRpcEndpoint::processBuffer(const QByteArray& buffer,
     QByteArray buf(buffer);
 
     JCON_ASSERT(buf[0] == '{');
+    if (buf[0] != '{') {
+        m_logger->logError("malformed request");
+        return nullptr;
+    }
 
     bool in_string = false;
     int brace_nesting_level = 0;


### PR DESCRIPTION
If jcon-cpp is built in release-mode, things might get weird when receiving a bad request.