### PR TITLE
Fixup for JsonRpcEndpoint::processBuffer

### DIFF
--- a/src/jcon/json_rpc_endpoint.cpp
+++ b/src/jcon/json_rpc_endpoint.cpp
@@ -153,12 +153,12 @@ QByteArray JsonRpcEndpoint::processBuffer(const QByteArray& buf,
         if (!in_string) {
             if (curr_ch == '{')
                 ++brace_nesting_level;
-            else  if (curr_ch == '}') {
+            else if (curr_ch == '}') {
                 --brace_nesting_level;
                 JCON_ASSERT(brace_nesting_level >= 0);
 
                 if (brace_nesting_level == 0) {
-                    auto doc = QJsonDocument::fromJson(buf.mid(start, i-start));
+                    auto doc = QJsonDocument::fromJson(buf.mid(start, i - start));
                     JCON_ASSERT(!doc.isNull());
                     JCON_ASSERT(doc.isObject());
                     if (doc.isObject())


### PR DESCRIPTION
These changes affect the code to the private method `JsonRpcEndpoint::processBuffer`:

1. Made the code support proper JSON strings that can contain escape characters, e.g. this request fragment, if encountered in the `params` payload  would fail previously:

```
 { "hello I have a \" quote in the middle and a closing brace!}" : "Hi" }
```

(Full example)
`{"jsonrpc": "2.0", "id":"hi", "method": "aMethod", "params": [ "hello I have a \" quote in the middle and a closing brace!}" : "Hi" ] }
`

The previous code would erroneously think the above JsonObject ended at `"brace}"` rather than where it should end, obviously limiting the types of data the server can accept without errors.

2. Made the code slightly more efficient by not constantly chopping the processed QByteArray but instead maintain an index to where we accepted the object (closing brace `}`).  This is a change needed for supporting batching in the future, since it reduces potential for copies while processing the receive buffer. (At the end we do chop the buffer on what we accepted, but not during the loop's iteration.)
