### PR TITLE
Add .pro files for QtCreator

### DIFF
--- a/jcon-cpp.pro
+++ b/jcon-cpp.pro
@@ -1,0 +1,8 @@
+CONFIG = ordered
+
+TEMPLATE = subdirs
+
+SUBDIRS = \
+    src/jcon/jcon.pro \
+    src/example.pro
+

--- a/src/example.pro
+++ b/src/example.pro
@@ -1,0 +1,13 @@
+QT += core network
+
+TEMPLATE = app
+
+# The lib jcon is built before the example in jcon-cpp.pro
+LIBS += -Ljcon -ljcon
+
+HEADERS = *.h
+SOURCES = *.cpp
+
+OTHER_FILES = CMakeLists.txt
+
+

--- a/src/jcon/jcon.pro
+++ b/src/jcon/jcon.pro
@@ -1,0 +1,8 @@
+QT += testlib websockets
+
+TEMPLATE = lib
+
+HEADERS = *.h
+SOURCES = *.cpp
+    
+OTHER_FILES = CMakeLists.txt


### PR DESCRIPTION
Add .pro files so that the Jcon library and examples can be built & run in one click from QtCreator.