### PR TITLE
Fix future signals triggers

### DIFF
--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -85,7 +85,12 @@ void JsonRpcTcpServer::newConnection()
         auto rpc_socket = std::make_shared<JsonRpcTcpSocket>(tcp_socket);
 
         auto endpoint =
-            std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
+            std::shared_ptr<JsonRpcEndpoint>(
+                new JsonRpcEndpoint(rpc_socket, log(), this),
+                [](JsonRpcEndpoint* obj) {
+                    obj->deleteLater();
+                }
+            );
 
         connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
                 this, &JsonRpcTcpServer::disconnectClient);

--- a/src/jcon/json_rpc_websocket_server.cpp
+++ b/src/jcon/json_rpc_websocket_server.cpp
@@ -82,7 +82,12 @@ void JsonRpcWebSocketServer::newConnection()
         auto rpc_socket = std::make_shared<JsonRpcWebSocket>(web_socket);
 
         auto endpoint =
-            std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
+            std::shared_ptr<JsonRpcEndpoint>(
+                new JsonRpcEndpoint(rpc_socket, log(), this),
+                [](JsonRpcEndpoint* obj) {
+                    obj->deleteLater();
+                }
+            );
 
         connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
                 this, &JsonRpcWebSocketServer::disconnectClient);


### PR DESCRIPTION
When using https://github.com/joncol/jcon-cpp/pull/41 to access the endpoint, if you connect new slots to the endpoint signals like `endpointDisconnected`, those slots will never be called because the endpoint is deleted automatically by the smart pointer when removed from the map. To respect all the connected slots, we need to use `deleteLater` which schedule the deletion at the end of the event loop. 