### PR TITLE
some qt 5.15 changes for windows build and more

### DIFF
--- a/src/jcon/json_rpc_client.cpp
+++ b/src/jcon/json_rpc_client.cpp
@@ -7,12 +7,11 @@
 #include <QUuid>
 #include <QEventLoop>
 #include <QCoreApplication>
+#include <QElapsedTimer>
 
 #include <memory>
 
 namespace jcon {
-
-const QString JsonRpcClient::InvalidRequestId = "";
 
 JsonRpcClient::JsonRpcClient(std::shared_ptr<JsonRpcSocket> socket,
                              QObject* parent,
@@ -73,7 +72,7 @@ JsonRpcClient::waitForSyncCallbacks(const JsonRpcRequest* request)
                     std::make_shared<JsonRpcError>(code, message, data);
             });
 
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
     while (m_outstanding_requests.contains(request->id()) &&
            timer.elapsed() < m_call_timeout_ms)

--- a/src/jcon/json_rpc_client.h
+++ b/src/jcon/json_rpc_client.h
@@ -97,7 +97,7 @@ private slots:
     void jsonResponseReceived(const QJsonObject& obj);
 
 private:
-    static const QString InvalidRequestId;
+    const QString InvalidRequestId = "";
 
     static QString formatLogMessage(const QString& method,
                                     const QVariantList& args,

--- a/src/jcon/json_rpc_server.cpp
+++ b/src/jcon/json_rpc_server.cpp
@@ -19,8 +19,6 @@ namespace {
 
 namespace jcon {
 
-const QString JsonRpcServer::InvalidRequestId = "";
-
 JsonRpcServer::JsonRpcServer(QObject* parent,
                              std::shared_ptr<JsonRpcLogger> logger)
     : QObject(parent)

--- a/src/jcon/json_rpc_server.h
+++ b/src/jcon/json_rpc_server.h
@@ -74,7 +74,7 @@ private slots:
     void serviceNotificationReceived(const QString& key, const QVariant& value);
 
 private:
-    static const QString InvalidRequestId;
+    const QString InvalidRequestId = "";
 
     bool dispatch(const QString& method_name,
                   const QVariant& params,

--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -125,7 +125,6 @@ void JsonRpcTcpServer::disconnectClient(QObject* client_socket)
 
 bool jcon::JsonRpcTcpServer::isListening() const {
     return m_server.isListening();
-
 }
 
 }

--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -123,4 +123,9 @@ void JsonRpcTcpServer::disconnectClient(QObject* client_socket)
     emit(clientDisconnected(client_socket));
 }
 
+bool jcon::JsonRpcTcpServer::isListening() const {
+    return m_server.isListening();
+
+}
+
 }

--- a/src/jcon/json_rpc_tcp_server.h
+++ b/src/jcon/json_rpc_tcp_server.h
@@ -41,7 +41,6 @@ private:
 
     /// Clients are uniquely identified by their QTcpSocket*.
     std::map<QTcpSocket*, std::shared_ptr<JsonRpcEndpoint>> m_client_endpoints;
-
 };
 
 }

--- a/src/jcon/json_rpc_tcp_server.h
+++ b/src/jcon/json_rpc_tcp_server.h
@@ -22,6 +22,7 @@ public:
 
     bool listen(int port) override;
     bool listen(const QHostAddress& addr, int port) override;
+    bool isListening() const;
     void close() override;
 
 protected:
@@ -40,6 +41,7 @@ private:
 
     /// Clients are uniquely identified by their QTcpSocket*.
     std::map<QTcpSocket*, std::shared_ptr<JsonRpcEndpoint>> m_client_endpoints;
+
 };
 
 }

--- a/src/jcon/json_rpc_tcp_socket.cpp
+++ b/src/jcon/json_rpc_tcp_socket.cpp
@@ -38,7 +38,7 @@ void JsonRpcTcpSocket::setupSocket()
     connect(m_socket, &QTcpSocket::readyRead,
             this, &JsonRpcTcpSocket::dataReady);
 
-#if (QT_VERSION > QT_VERSION_CHECK(5,15, 0))
+#if (QT_VERSION > QT_VERSION_CHECK(5, 15, 0))
     void (QAbstractSocket::*errorFun)(QAbstractSocket::SocketError) =
         &QAbstractSocket::errorOccurred;
 #else

--- a/src/jcon/json_rpc_tcp_socket.cpp
+++ b/src/jcon/json_rpc_tcp_socket.cpp
@@ -38,8 +38,14 @@ void JsonRpcTcpSocket::setupSocket()
     connect(m_socket, &QTcpSocket::readyRead,
             this, &JsonRpcTcpSocket::dataReady);
 
+#if (QT_VERSION > QT_VERSION_CHECK(5,15, 0))
+    void (QAbstractSocket::*errorFun)(QAbstractSocket::SocketError) =
+        &QAbstractSocket::errorOccurred;
+#else
     void (QAbstractSocket::*errorFun)(QAbstractSocket::SocketError) =
         &QAbstractSocket::error;
+#endif
+
     connect(m_socket, errorFun, this,
             [this](QAbstractSocket::SocketError error) {
                 emit socketError(m_socket, error);

--- a/src/jcon/json_rpc_websocket.cpp
+++ b/src/jcon/json_rpc_websocket.cpp
@@ -5,6 +5,7 @@
 #include <QtWebSockets/QWebSocket>
 #include <QEventLoop>
 #include <QCoreApplication>
+#include <QElapsedTimer>
 
 namespace jcon {
 
@@ -63,7 +64,7 @@ void JsonRpcWebSocket::connectToUrl(const QUrl& url)
 
 bool JsonRpcWebSocket::waitForConnected(int msecs)
 {
-    QTime timer(0, 0, 0, msecs);
+    QElapsedTimer timer;
     bool isConnected = false;
     QObject guard;
     connect(m_socket, &QWebSocket::connected,

--- a/src/jcon/json_rpc_websocket_server.cpp
+++ b/src/jcon/json_rpc_websocket_server.cpp
@@ -40,6 +40,10 @@ bool JsonRpcWebSocketServer::listen(const QHostAddress& addr, int port)
     return m_server->listen(addr, port);
 }
 
+bool JsonRpcWebSocketServer::isListening() const {
+    return m_server->isListening();
+}
+
 void JsonRpcWebSocketServer::close()
 {
     m_server->close();

--- a/src/jcon/json_rpc_websocket_server.h
+++ b/src/jcon/json_rpc_websocket_server.h
@@ -23,6 +23,7 @@ public:
 
     bool listen(int port) override;
     bool listen(const QHostAddress& addr, int port) override;
+    bool isListening() const ;
     void close() override;
 
 protected:

--- a/src/jcon/json_rpc_websocket_server.h
+++ b/src/jcon/json_rpc_websocket_server.h
@@ -23,7 +23,7 @@ public:
 
     bool listen(int port) override;
     bool listen(const QHostAddress& addr, int port) override;
-    bool isListening() const ;
+    bool isListening() const;
     void close() override;
 
 protected:


### PR DESCRIPTION
added isListening for some checks
seems invalidrequest don't need to be static
QAbstractSocket::error func deprecated to errorOccured