### PR TITLE
Fix future signals triggers except when server is closed

### DIFF
--- a/src/jcon/json_rpc_tcp_server.cpp
+++ b/src/jcon/json_rpc_tcp_server.cpp
@@ -85,7 +85,14 @@ void JsonRpcTcpServer::newConnection()
         auto rpc_socket = std::make_shared<JsonRpcTcpSocket>(tcp_socket);
 
         auto endpoint =
-            std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
+            std::shared_ptr<JsonRpcEndpoint>(new JsonRpcEndpoint(rpc_socket, log(), this),
+                [this](JsonRpcEndpoint* obj) {
+                    if (this->m_server.isListening()) {
+                        obj->deleteLater();
+                    } else {
+                        delete obj;
+                    }
+                });
 
         connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
                 this, &JsonRpcTcpServer::disconnectClient);

--- a/src/jcon/json_rpc_websocket_server.cpp
+++ b/src/jcon/json_rpc_websocket_server.cpp
@@ -86,7 +86,14 @@ void JsonRpcWebSocketServer::newConnection()
         auto rpc_socket = std::make_shared<JsonRpcWebSocket>(web_socket);
 
         auto endpoint =
-            std::make_shared<JsonRpcEndpoint>(rpc_socket, log(), this);
+            std::shared_ptr<JsonRpcEndpoint>(new JsonRpcEndpoint(rpc_socket, log(), this),
+                [this](JsonRpcEndpoint* obj) {
+                    if (this->m_server != nullptr && this->m_server->isListening()) {
+                        obj->deleteLater();
+                    } else {
+                        delete obj;
+                    }
+                });
 
         connect(endpoint.get(), &JsonRpcEndpoint::socketDisconnected,
                 this, &JsonRpcWebSocketServer::disconnectClient);


### PR DESCRIPTION
This fixes https://github.com/joncol/jcon-cpp/pull/67.
Anyway the bug happened only using TCP, maybe because websocket uses a pointer to the m_server so the order of deconstruction is different, this anyway works for both. Please check before merge.