### PR TITLE
Fix missing QMap include in json_rpc_server.h

### DIFF
--- a/src/jcon/json_rpc_server.h
+++ b/src/jcon/json_rpc_server.h
@@ -3,6 +3,7 @@
 #include "jcon.h"
 #include "json_rpc_logger.h"
 
+#include <QMap>
 #include <QAbstractSocket>
 
 #include <memory>


### PR DESCRIPTION
After recent changes in Qt headers, QMap is no longer indirectly included by other Qt headers.
This causes build failure:
`error: field ‘m_services’ has incomplete type ‘QMap<QObject*, QString>’`

This fix is quite simple, adding `#include <QMap>` to `json_rpc_server.h` (as in `json_rpc_client.h`)

Tested with Qt 4.9.1, GCC 14.3.0, Clang 20.1.7